### PR TITLE
Fix cleanup for IPv64 sensors

### DIFF
--- a/custom_components/ipv64/sensor.py
+++ b/custom_components/ipv64/sensor.py
@@ -48,6 +48,7 @@ class IPv64BaseEntity(CoordinatorEntity[IPv64DataUpdateCoordinator], RestoreSens
 
     async def async_will_remove_from_hass(self) -> None:
         """Clean up before removing the entity."""
+        await super().async_will_remove_from_hass()
         _LOGGER.debug("Entity %s removed from Home Assistant", self.entity_id)
 
 


### PR DESCRIPTION
## Summary
- ensure base sensor class calls super when removed

## Testing
- `ruff check --fix custom_components/ipv64/sensor.py`
- `ruff format custom_components/ipv64/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b77e09208325bb407066b9fc3941