### PR TITLE
Fix translation URL validation

### DIFF
--- a/custom_components/ipv64/services.yaml
+++ b/custom_components/ipv64/services.yaml
@@ -4,7 +4,7 @@ refresh:
   fields:
     economy:
       name: "Economy-Modus"
-      description: "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)."
+      description: "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)."
       selector:
         boolean:
 add_domain:

--- a/custom_components/ipv64/strings.json
+++ b/custom_components/ipv64/strings.json
@@ -15,7 +15,7 @@
     "step": {
       "user": {
         "data": {
-          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "apikey": "API-Schlüssel",
           "domain": "Domain",
           "scan_interval": "Aktualisierungsintervall (0-120 Minuten, 0=deaktiviert)",
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "data": {
-          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "scan_interval": "Aktualisierungsintervall (0-120 Minuten, 0=deaktiviert)"
         },
         "description": "Konfigurieren Sie das Aktualisierungsintervall und den Economy-Modus. Mit einem kostenlosen Konto stehen Ihnen 64 Updates pro Tag zur Verfügung. Das empfohlene Intervall beträgt 23 Minuten (24 Stunden ÷ 64 Updates ≈ 22,5 Minuten).",
@@ -43,7 +43,7 @@
       "description": "IP-Adresse manuell aktualisieren. Beachten Sie: Jede Aktualisierung verbraucht 1 von 64 täglichen Tokens.",
       "fields": {
         "economy": {
-          "description": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "description": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "name": "Economy-Modus"
         }
       },

--- a/custom_components/ipv64/translations/de.json
+++ b/custom_components/ipv64/translations/de.json
@@ -15,7 +15,7 @@
     "step": {
       "user": {
         "data": {
-          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "apikey": "API-Schlüssel",
           "domain": "Domain",
           "scan_interval": "Aktualisierungsintervall (0-120 Minuten, 0=deaktiviert)",
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "data": {
-          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "scan_interval": "Aktualisierungsintervall (0-120 Minuten, 0=deaktiviert)"
         },
         "description": "Konfigurieren Sie das Aktualisierungsintervall und den Economy-Modus. Mit einem kostenlosen Konto stehen Ihnen 64 Updates pro Tag zur Verfügung. Das empfohlene Intervall beträgt 23 Minuten (24 Stunden ÷ 64 Updates ≈ 22,5 Minuten).",
@@ -43,7 +43,7 @@
       "description": "IP-Adresse manuell aktualisieren. Beachten Sie: Jede Aktualisierung verbraucht 1 von 64 täglichen Tokens.",
       "fields": {
         "economy": {
-          "description": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft via https://checkip.amazonaws.com/)",
+          "description": "Economy-Modus aktivieren (Updates nur bei IP-Änderung, geprüft über einen externen IP-Dienst)",
           "name": "Economy-Modus"
         }
       },

--- a/custom_components/ipv64/translations/en.json
+++ b/custom_components/ipv64/translations/en.json
@@ -15,7 +15,7 @@
     "step": {
       "user": {
         "data": {
-          "api_key_economy": "Enable economy mode (updates only when IP changes, checked via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Enable economy mode (updates only when IP changes, checked via an external IP service)",
           "apikey": "API Key",
           "domain": "Domain",
           "scan_interval": "Update interval (0-120 minutes, 0=disabled)",
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "data": {
-          "api_key_economy": "Enable economy mode (updates only when IP changes, checked via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Enable economy mode (updates only when IP changes, checked via an external IP service)",
           "scan_interval": "Update interval (0-120 minutes, 0=disabled)"
         },
         "description": "Configure the update interval and economy mode. Free accounts have 64 updates per day. Recommended interval: 23 minutes (24 hours ÷ 64 updates ≈ 22.5 minutes).",
@@ -45,7 +45,7 @@
       "fields": {
         "economy": {
           "name": "Economy Mode",
-          "description": "Enable economy mode (updates only when IP changes, checked via https://checkip.amazonaws.com/)"
+          "description": "Enable economy mode (updates only when IP changes, checked via an external IP service)"
         }
       }
     },

--- a/custom_components/ipv64/translations/pt.json
+++ b/custom_components/ipv64/translations/pt.json
@@ -15,7 +15,7 @@
     "step": {
       "user": {
         "data": {
-          "api_key_economy": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado por um serviço externo de IP)",
           "apikey": "Chave de API",
           "domain": "Domínio",
           "scan_interval": "Intervalo de atualização (0-120 minutos, 0=desativado)",
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "data": {
-          "api_key_economy": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado via https://checkip.amazonaws.com/)",
+          "api_key_economy": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado por um serviço externo de IP)",
           "scan_interval": "Intervalo de atualização (0-120 minutos, 0=desativado)"
         },
         "description": "Configure o intervalo de atualização e o modo econômico. Com uma conta gratuita, você tem 64 atualizações por dia. O intervalo recomendado é de 23 minutos (24 horas ÷ 64 atualizações ≈ 22,5 minutos).",
@@ -43,7 +43,7 @@
       "description": "Atualizar manualmente o endereço IP. Nota: Cada atualização consome 1 dos 64 tokens diários.",
       "fields": {
         "economy": {
-          "description": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado via https://checkip.amazonaws.com/)",
+          "description": "Ativar modo econômico (atualiza apenas quando o IP muda, verificado por um serviço externo de IP)",
           "name": "Modo Econômico"
         }
       },

--- a/custom_components/ipv64/translations/sk.json
+++ b/custom_components/ipv64/translations/sk.json
@@ -15,7 +15,7 @@
     "step": {
       "user": {
         "data": {
-          "api_key_economy": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez https://checkip.amazonaws.com/)",
+          "api_key_economy": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez externú službu IP)",
           "apikey": "Kľúč API",
           "domain": "Doména",
           "scan_interval": "Interval aktualizácie (0–120 minút, 0=vypnuté)",
@@ -30,7 +30,7 @@
     "step": {
       "init": {
         "data": {
-          "api_key_economy": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez https://checkip.amazonaws.com/)",
+          "api_key_economy": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez externú službu IP)",
           "scan_interval": "Interval aktualizácie (0–120 minút, 0=vypnuté)"
         },
         "description": "Nakonfigurujte interval aktualizácie a ekonomický režim. S bezplatným účtom máte k dispozícii 64 aktualizácií denne. Odporúčaný interval je 23 minút (24 hodín ÷ 64 aktualizácií ≈ 22,5 minúty).",
@@ -43,7 +43,7 @@
       "description": "Manuálne aktualizovať IP adresu. Poznámka: Každá aktualizácia spotrebuje 1 zo 64 denných tokenov.",
       "fields": {
         "economy": {
-          "description": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez https://checkip.amazonaws.com/)",
+          "description": "Povoliť ekonomický režim (aktualizácie iba pri zmene IP, overené cez externú službu IP)",
           "name": "Ekonomický režim"
         }
       },


### PR DESCRIPTION
### Motivation
- Home Assistant translation validation rejects literal URLs in translation strings, so the economy mode labels and service descriptions needed replacement to pass validation.
- Keep the user-visible meaning about IP checks while removing the hard-coded `https://checkip.amazonaws.com/` URL from translations and service metadata.

### Description
- Replaced occurrences of `https://checkip.amazonaws.com/` with a generic reference to an "external IP service" in `custom_components/ipv64/strings.json`, `custom_components/ipv64/translations/en.json`, `custom_components/ipv64/translations/de.json`, `custom_components/ipv64/translations/pt.json`, and `custom_components/ipv64/translations/sk.json`.
- Updated the `economy` field description in `custom_components/ipv64/services.yaml` to remove the literal URL and use the localized external-service phrasing.
- These changes are text-only and do not modify runtime code or behavior.

### Testing
- Validated JSON syntax with `python -m json.tool` for `custom_components/ipv64/strings.json` and the modified translation files, which succeeded.
- Ran a Python check that walks the translation JSONs to ensure no `http://` or `https://` strings remain, which reported no URLs found.
- Parsed `custom_components/ipv64/services.yaml` with `yaml.safe_load(...)` to verify the YAML is valid, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d68986bc8325bbdc6d3e6008952b)