### PR TITLE
Group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       time: "22:30"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     labels:
       - "in progress"
       - "dependencies"


### PR DESCRIPTION
### Motivation
- Batch Dependabot updates for the CodeQL GitHub Action so updates matching `github/codeql-action*` are grouped together instead of opening separate PRs.

### Description
- Add a `groups` entry to `.github/dependabot.yml` under the `github-actions` update config with group `codeql-action` and `patterns` containing `github/codeql-action*`.

### Testing
- Ran a YAML validation snippet `python - <<'PY' ... PY` that loads `.github/dependabot.yml` and asserts the new group pattern exists, and the check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50eed6e3188325ae553b57db9e5866)